### PR TITLE
Subclass NSDocumentController

### DIFF
--- a/YCodeDocumentController.h
+++ b/YCodeDocumentController.h
@@ -28,7 +28,7 @@
 #import <Foundation/Foundation.h>
 #import <AppKit/AppKit.h>
 
-@interface YCodeDocumentController : NSDocumentControllers
+@interface YCodeDocumentController : NSDocumentController
 {
 
 }


### PR DESCRIPTION
Because `NSDocumentController` is a thing, and `NSDocumentControllers` isn't :)